### PR TITLE
Indicate missing parameters

### DIFF
--- a/src/Clarg/ArgumentsProvider.cs
+++ b/src/Clarg/ArgumentsProvider.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Clarg
+{
+	public class ArgumentsProvider
+	{
+		public static TArguments Parse<TArguments>(string[] args)
+			where TArguments : class
+		{
+			var parserResult = new Parser().Create<TArguments>(args);
+			return parserResult.Value;
+		}
+
+		public static void WriteErrorToConsole<TArguments>(string[] args)
+			where TArguments : class
+		{
+			var parserResult = new Parser().Create<TArguments>(args);
+
+			if(parserResult.Value != null)
+				return;
+
+			var errorMessage = new ParserSuggestionFormatter()
+				.CreateErrorMessage(
+					Environment.GetCommandLineArgs()[0],
+					parserResult.Suggestions);
+
+			new ConsoleStringRenderer()
+				.WriteLine(errorMessage);
+		}
+	}
+}

--- a/src/Clarg/ConsoleString.cs
+++ b/src/Clarg/ConsoleString.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Clarg
+{
+	public class ConsoleString
+	{
+		public readonly IEnumerable<ConsoleStringSegment> Segments;
+
+		public ConsoleString(params ConsoleStringSegment[] segments)
+		{
+			Segments = segments ?? Enumerable.Empty<ConsoleStringSegment>();
+		}
+
+		public ConsoleString(IEnumerable<ConsoleStringSegment> segments)
+		{
+			Segments = segments ?? Enumerable.Empty<ConsoleStringSegment>();
+		}
+
+		public ConsoleString(IEnumerable<ConsoleString> values)
+		{
+			Segments = (values ?? Enumerable.Empty<ConsoleString>())
+				.SelectMany(value => value.Segments)
+				.ToArray();
+		}
+
+		public int GetLength()
+			=> Segments.Sum(segment => segment.Text.Length);
+
+		public ConsoleString PadRight(int totalWidth, char paddingCharacter = ' ')
+			=> GetLength() >= totalWidth
+				? this
+				: this + new string(paddingCharacter, totalWidth - GetLength());
+
+		public static ConsoleString Join(ConsoleStringSegment separator, IEnumerable<ConsoleString> values)
+		{
+			var valuesCount = values.Count();
+
+			if(valuesCount == 0)
+				return new ConsoleString();
+
+			if(valuesCount == 1)
+				return values.First();
+
+			var joinedSegments = Enumerable.Empty<ConsoleStringSegment>();
+
+			// Copy all but the last element with a separator
+			for(var index = 0; index < valuesCount - 1; index++)
+				joinedSegments = joinedSegments
+					.Concat(values.ElementAt(index).Segments)
+					.Concat(new[] { separator });
+
+			// Copy the last element without a separator
+			joinedSegments = joinedSegments.Concat(values.ElementAt(valuesCount - 1).Segments);
+
+			return new ConsoleString(joinedSegments);
+		}
+
+		public ConsoleString Colored(ConsoleColor? foreground = null, ConsoleColor? background = null)
+			=> new ConsoleString(Segments
+				.Select(segment => new ConsoleStringSegment(
+					segment.Text,
+					foreground ?? segment.Foreground,
+					background ?? segment.Background)));
+
+		public override string ToString()
+			=> string.Join(
+				string.Empty,
+				Segments.SelectMany(segment => segment.Text));
+
+		public static ConsoleString operator +(ConsoleString left, ConsoleStringSegment right)
+			=> new ConsoleString(left
+				.Segments
+				.Concat(new[] { right })
+				.ToArray());
+
+		public static ConsoleString operator +(ConsoleString left, string right)
+			=> new ConsoleString(left
+				.Segments
+				.Concat(new[] { new ConsoleStringSegment(right) })
+				.ToArray());
+
+		public static ConsoleString operator +(ConsoleString left, ConsoleString right)
+			=> new ConsoleString(left
+				.Segments
+				.Concat(right.Segments)
+				.ToArray());
+
+		public static implicit operator ConsoleString(string text)
+			=> new ConsoleString(new ConsoleStringSegment(text));
+
+		public static implicit operator ConsoleString(ConsoleStringSegment segment)
+			=> new ConsoleString(segment);
+	}
+
+	public class ConsoleStringSegment
+	{
+		public readonly string Text;
+		public readonly ConsoleColor? Foreground;
+		public readonly ConsoleColor? Background;
+
+		public ConsoleStringSegment(string text, ConsoleColor? foreground = null, ConsoleColor? background = null)
+		{
+			Text = text ?? string.Empty;
+			Foreground = foreground;
+			Background = background;
+		}
+
+		public static implicit operator ConsoleStringSegment(string text)
+			=> new ConsoleStringSegment(text);
+
+		public override string ToString()
+			=> Text;
+	}
+}

--- a/src/Clarg/ConsoleStringRenderer.cs
+++ b/src/Clarg/ConsoleStringRenderer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Clarg
+{
+	public class ConsoleStringRenderer
+	{
+		public void WriteLine(ConsoleString value)
+		{
+			Write(value);
+			Console.WriteLine();
+		}
+
+		public void Write(ConsoleString value)
+		{
+			var originalForeground = Console.ForegroundColor;
+			var originalBackground = Console.BackgroundColor;
+
+			foreach(var segment in value.Segments)
+			{
+				if(segment.Foreground.HasValue)
+					Console.ForegroundColor = segment.Foreground.Value;
+
+				if(segment.Background.HasValue)
+					Console.BackgroundColor = segment.Background.Value;
+
+				Console.Write(segment.Text);
+
+				Console.ForegroundColor = originalForeground;
+				Console.BackgroundColor = originalBackground;
+			}
+		}
+	}
+}

--- a/src/Clarg/FormattedArgument.cs
+++ b/src/Clarg/FormattedArgument.cs
@@ -3,10 +3,10 @@
 	class FormattedArgument
 	{
 		public readonly ParserSuggestionArgument Argument;
-		public readonly string DisplayName;
-		public readonly string DisplayType;
+		public readonly ConsoleString DisplayName;
+		public readonly ConsoleString DisplayType;
 
-		public FormattedArgument(ParserSuggestionArgument argument, string displayName, string displayType)
+		public FormattedArgument(ParserSuggestionArgument argument, ConsoleString displayName, ConsoleString displayType)
 		{
 			Argument = argument;
 			DisplayName = displayName;

--- a/src/Clarg/ParserSuggestionArgument.cs
+++ b/src/Clarg/ParserSuggestionArgument.cs
@@ -12,16 +12,18 @@ namespace Clarg
 		public readonly string Name;
 		public readonly string Description;
 		public readonly Type Type;
+		public readonly bool? IsFulfilled;
 		public readonly bool IsEnumerable;
 		public readonly bool IsOptional;
 		public readonly bool IsParams;
 		public readonly Type InnerType;
 
-		public ParserSuggestionArgument(string name, string description, Type type, bool isEnumerable, bool isOptional, bool isParams)
+		public ParserSuggestionArgument(string name, string description, Type type, bool? isFulfilled, bool isEnumerable, bool isOptional, bool isParams)
 		{
 			Name = name;
 			Description = description;
 			Type = type;
+			IsFulfilled = isFulfilled;
 			IsEnumerable = isEnumerable;
 			IsOptional = isOptional;
 			IsParams = isParams;
@@ -38,18 +40,23 @@ namespace Clarg
 
 		public override bool Equals(object obj)
 			=> obj is ParserSuggestionArgument
-				? Equals(this, (ParserSuggestionArgument)obj)
-				: false;
+				&& Equals(this, (ParserSuggestionArgument)obj);
 
 		bool Equals(ParserSuggestionArgument x, ParserSuggestionArgument y)
 		{
 			if(ReferenceEquals(x, null) || ReferenceEquals(y, null))
 				return ReferenceEquals(x, null) && ReferenceEquals(y, null);
 
+			if(ReferenceEquals(x, y))
+				return true;
+
 			if(!StringComparer.OrdinalIgnoreCase.Equals(x.Name, y.Name))
 				return false;
 
 			if(x.Type != y.Type)
+				return false;
+
+			if(x.IsFulfilled != y.IsFulfilled)
 				return false;
 
 			if(x.IsEnumerable != y.IsEnumerable)
@@ -72,6 +79,7 @@ namespace Clarg
 			{
 				hashCode = hashCode * HashCodeFactor + Name?.GetHashCode() ?? 0;
 				hashCode = hashCode * HashCodeFactor + Type?.GetHashCode() ?? 0;
+				hashCode = hashCode * HashCodeFactor + IsFulfilled.GetHashCode();
 				hashCode = hashCode * HashCodeFactor + IsEnumerable.GetHashCode();
 				hashCode = hashCode * HashCodeFactor + IsOptional.GetHashCode();
 				hashCode = hashCode * HashCodeFactor + IsParams.GetHashCode();

--- a/src/Clarg/project.json
+++ b/src/Clarg/project.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.0.0-*",
+	"version": "3.1.0-*",
 
 	"description": "Command Line Arguments Parser",
 	"authors": [ "jason@vortx.com", "josh@vortx.com" ],

--- a/test/Clarg.Test/ParserErrorDisplay.cs
+++ b/test/Clarg.Test/ParserErrorDisplay.cs
@@ -47,7 +47,9 @@ namespace Tests
 			Assert.IsType<ParserError<DecoratedArguments>>(parserResult);
 
 			var parserSuggestionFormatter = new ParserSuggestionFormatter();
-			var result = parserSuggestionFormatter.CreateErrorMessage(Command, parserResult.Suggestions);
+			var result = parserSuggestionFormatter
+				.CreateErrorMessage(Command, parserResult.Suggestions)
+				.ToString();
 
 			Assert.NotNull(result);
 			Assert.Contains(Command, result);


### PR DESCRIPTION
Implemented support for visual indication (color and surrounding characters) of missing parameters in rendered error messages.